### PR TITLE
Move boardid configuration out of erlinit.config

### DIFF
--- a/rootfs_overlay/etc/boardid.config
+++ b/rootfs_overlay/etc/boardid.config
@@ -1,0 +1,10 @@
+# boardid.config
+
+# Read the serial number from the U-boot environment block. The variable
+# "nerves_serial_number" is the desired variable to use. "serial_number" is
+# checked as a backup.
+-b uboot_env -u nerves_serial_number
+-b uboot_env -u serial_number
+
+# Last resort, use 4 digits of the RPi's unique ID as the serial number
+-b rpi -n 4

--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -55,10 +55,9 @@
 # Erlang release search path
 -r /srv/erlang
 
-# Assign a hostname of the form "nerves-<serial_number>". The serial number is either
-# read from the U-boot environment block that contains provisioning information from
-# manufacturing or it uses 4 digits of the Raspberry Pi's device ID
--d "/usr/bin/boardid -b uboot_env -u nerves_serial_number -b uboot_env -u serial_number -b rpi -n 4"
+# Assign a hostname of the form "nerves-<serial_number>".
+# See /etc/boardid.config for locating the serial number.
+-d /usr/bin/boardid
 -n nerves-%s
 
 # If using shoehorn (https://github.com/nerves-project/shoehorn), start the


### PR DESCRIPTION
This makes it possible to call "boardid" from anywhere and get the
intended ID.