### PR TITLE
Include all RaspberryPi camera device tree overlays

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -24,6 +24,9 @@ dtparam=i2c_arm=on
 dtparam=spi=on
 dtparam=audio=on
 
+# Automatically load overlays for detected cameras
+camera_auto_detect=1
+
 # Enable drivers for the Raspberry Pi 7" Touchscreen
 #
 # This makes it possible to run Scenic out of the box with the popular

--- a/fwup.conf
+++ b/fwup.conf
@@ -55,6 +55,27 @@ file-resource miniuart-bt.dtbo {
 file-resource ramoops.dtbo {
     host-path = "${NERVES_SYSTEM}/images/ramoops.dtb"
 }
+file-resource imx219.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/imx219.dtbo"
+}
+file-resource imx296.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/imx296.dtbo"
+}
+file-resource imx477.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/imx477.dtbo"
+}
+file-resource imx708.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/imx708.dtbo"
+}
+file-resource ov5647.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/ov5647.dtbo"
+}
+file-resource i2c-mux.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/i2c-mux.dtbo"
+}
+file-resource tc358743.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/tc358743.dtbo"
+}
 
 file-resource rootfs.img {
     host-path = ${ROOTFS}
@@ -161,6 +182,13 @@ task complete {
     on-resource dwc2.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/dwc2.dtbo") }
     on-resource miniuart-bt.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
     on-resource ramoops.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/ramoops.dtbo") }
+    on-resource imx219.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx219.dtbo") }
+    on-resource imx296.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx296.dtbo") }
+    on-resource imx477.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx477.dtbo") }
+    on-resource imx708.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx708.dtbo") }
+    on-resource ov5647.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/ov5647.dtbo") }
+    on-resource i2c-mux.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c-mux.dtbo") }
+    on-resource tc358743.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/tc358743.dtbo") }
 
     on-resource rootfs.img {
         # write to the first rootfs partition
@@ -229,6 +257,14 @@ task upgrade.a {
     on-resource dwc2.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/dwc2.dtbo") }
     on-resource miniuart-bt.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
     on-resource ramoops.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/ramoops.dtbo") }
+    on-resource imx219.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx219.dtbo") }
+    on-resource imx296.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx296.dtbo") }
+    on-resource imx477.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx477.dtbo") }
+    on-resource imx708.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx708.dtbo") }
+    on-resource ov5647.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/ov5647.dtbo") }
+    on-resource i2c-mux.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c-mux.dtbo") }
+    on-resource tc358743.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/tc358743.dtbo") }
+
     on-resource rootfs.img {
         delta-source-raw-offset=${ROOTFS_B_PART_OFFSET}
         delta-source-raw-count=${ROOTFS_B_PART_COUNT}
@@ -304,6 +340,14 @@ task upgrade.b {
     on-resource dwc2.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/dwc2.dtbo") }
     on-resource miniuart-bt.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
     on-resource ramoops.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/ramoops.dtbo") }
+    on-resource imx219.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx219.dtbo") }
+    on-resource imx296.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx296.dtbo") }
+    on-resource imx477.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx477.dtbo") }
+    on-resource imx708.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx708.dtbo") }
+    on-resource ov5647.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/ov5647.dtbo") }
+    on-resource i2c-mux.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c-mux.dtbo") }
+    on-resource tc358743.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/tc358743.dtbo") }
+
     on-resource rootfs.img {
         delta-source-raw-offset=${ROOTFS_A_PART_OFFSET}
         delta-source-raw-count=${ROOTFS_A_PART_COUNT}


### PR DESCRIPTION
- **Include all RaspberryPi camera device tree overlays**
- **Instruct the bootloader to autoload overlays for cameras**
